### PR TITLE
Increase Axios timeout and adjust query retry settings

### DIFF
--- a/apps/admin/src/lib/axios.ts
+++ b/apps/admin/src/lib/axios.ts
@@ -3,7 +3,7 @@ import { createClient } from "@/lib/supabase/client";
 
 const api = axios.create({
 	baseURL: `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1`,
-	timeout: 1000,
+	timeout: 10000,
 	headers: {
 		"Content-Type": "application/json",
 	},

--- a/apps/admin/src/lib/query-client.ts
+++ b/apps/admin/src/lib/query-client.ts
@@ -4,11 +4,11 @@ export const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: {
 			staleTime: 5 * 60 * 1000,
-			retry: 1,
+			retry: 3,
 			refetchOnWindowFocus: false,
 		},
 		mutations: {
-			retry: 1,
+			retry: 3,
 		},
 	},
 });


### PR DESCRIPTION
- Updated Axios timeout from 1000ms to 10000ms to improve API request handling.
- Increased retry attempts for queries and mutations from 1 to 3 to enhance resilience in data fetching.